### PR TITLE
Update dependencies and build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ jdk: oraclejdk8
 
 env:
   global:
-    - ANDROID_API_LEVEL=24
-    - ANDROID_BUILD_TOOLS_VERSION=27.0.3
-    - ANDROID_ABI=armeabi-v7a
     - ADB_INSTALL_TIMEOUT=5
+    - ANDROID_ABI=armeabi-v7a
     # storepass
     - secure: "cRdupUus7UsluRI62V2nmfXZaWM90aL657EBM+KH20FlHMR5KQc0ILN+2dGYygRS2sydI9n2tPPnmzWFKGIw6KrbzsAFNJDFubyLnBv0+Gpt5AXVmvXH/RFcnfcdrm4jyNhcuwpGqJrgaG9mUpDioT4zQlTtCAtQUgXyk4m40Q3dSSaxP7w5VtKIZE6wFtInqP0eUhwaW1srjaDZ7WVDdJsvKM7ou65oCEK5bRXLHwqSWKxrJx+iJ07KTFtdS1vYmM9MTLsiGtorLixH0QixmsRo/cDP0QO4n98w5cc7aKUSGtSLlKKxiRS6gsh1QWIjo/YtABIgyxgu6BGYIeYKbjizVrmfGJZyZ2aDJx3PBVvbd5sQmqRIccEZBR9G5K4UrM+f2Hweo5PsXATRBdKwrEi6dJmzh4hwKNpYCpyyi0eSJNgN1STHazVE3RRnFoNciGROCcECQauZ2vZigfAKlOZdQqmKtUgXV2yTU//b79NoVkiRKeVx5kpGcxwHhtBGY1GP6QfPj8C64I0RDuZKEpDq964dgjFUDxIfj9Hdep1123VxcHgddKDjpH6T3IoRFEvsMiWhayv90RACe2VKPOa2wD9YbjWkrISKUQh9Ru26sBn5OzkypNdmClKkRbLZk5CNlNub6q+uIOa/yxy8hf2+MxXrQ/uf6QqKDQdT9Vs="
 
@@ -17,18 +15,14 @@ android:
     - platform-tools
     - tools
   licenses:
-    - android-sdk-preview-license-52d11cd2
-    - android-sdk-license-.+
-    - google-gdk-license-.+
+    - 'android-sdk-preview-license-.+'
+    - 'android-sdk-license-.+'
+    - 'google-gdk-license-.+'
 
 before_install:
-  - openssl aes-256-cbc -K $encrypted_d4f65c79752c_key -iv $encrypted_d4f65c79752c_iv -in android-keys.jks.enc -out android-keys.jks -d
   - touch $HOME/.android/repositories.cfg
-  - yes | sdkmanager "platforms;android-24"
-  - yes | sdkmanager "build-tools;27.0.3"
-  - mkdir -p "$ANDROID_HOME/licenses"
-  - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_HOME/licenses/android-sdk-license"
-  - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
+  - yes | sdkmanager "platforms;android-28"
+  - openssl aes-256-cbc -K $encrypted_d4f65c79752c_key -iv $encrypted_d4f65c79752c_iv -in android-keys.jks.enc -out android-keys.jks -d
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -39,6 +33,9 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     - $HOME/.android/build-cache
+
+before_script:
+  - chmod +x gradlew
 
 script:
   - ./gradlew --no-daemon clean build

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,14 @@ script:
 
 before_deploy:
   - openssl aes-256-cbc -K $encrypted_d4f65c79752c_key -iv $encrypted_d4f65c79752c_iv -in android-keys.jks.enc -out android-keys.jks -d
+  - build_tools_version=$(ls -1 ${ANDROID_HOME}/build-tools | tail -n 1)
   - |
     apks=($(find "$TRAVIS_BUILD_DIR" -name '*release*.apk'))
     for apk in "${apks[@]}"; do
       signedFile="$TRAVIS_BUILD_DIR/$(basename "$apk" | sed 's/unsigned/signed/')"
       jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 -keystore $TRAVIS_BUILD_DIR/android-keys.jks -storepass $storepass "$apk" atvlaunchers
       jarsigner -verify "$apk"
-      ${ANDROID_HOME}/build-tools/27.0.3/zipalign -v 4 "$apk" "$signedFile"
+      ${build_tools_version}/zipalign -v 4 "$apk" "$signedFile"
     done
   - pwd && ls -la
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ android:
 before_install:
   - touch $HOME/.android/repositories.cfg
   - yes | sdkmanager "platforms;android-28"
-  - openssl aes-256-cbc -K $encrypted_d4f65c79752c_key -iv $encrypted_d4f65c79752c_iv -in android-keys.jks.enc -out android-keys.jks -d
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -41,6 +40,7 @@ script:
   - ./gradlew --no-daemon clean build
 
 before_deploy:
+  - openssl aes-256-cbc -K $encrypted_d4f65c79752c_key -iv $encrypted_d4f65c79752c_iv -in android-keys.jks.enc -out android-keys.jks -d
   - |
     apks=($(find "$TRAVIS_BUILD_DIR" -name '*release*.apk'))
     for apk in "${apks[@]}"; do

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,23 +1,25 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 28
     flavorDimensions "versionCode"
+
     defaultConfig {
         applicationId "hosh.io.atv_launchers"
         minSdkVersion 24
-        //noinspection ExpiredTargetSdkVersion
-        targetSdkVersion 24
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    productFlavors{
+
+    productFlavors {
         iPlayer {
             applicationIdSuffix = ".iPlayer"
         }
@@ -45,8 +47,6 @@ android {
 }
 
 dependencies {
-    implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.android.support:leanback-v17:24.2.1'
-    implementation 'com.android.support:appcompat-v7:24.2.1'
-    implementation 'com.github.bumptech.glide:glide:3.8.0'
+    implementation 'androidx.leanback:leanback:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,10 @@
 buildscript {
-    
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.5.0'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,12 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+android.useAndroidX=true
+# Automatically convert third-party libraries to use AndroidX
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip


### PR DESCRIPTION
- Update to latest stable version of Android SDK (28).
- Since version 3 of the Android Gradle plugin the supported build-tools version is installed automatically. Therefore, removed setting this manually and removed installing this manually in the Travis configuration.
- Update the deprecated Android support library dependencies and use latest stable Android X versions instead.
- Remove unused Glide and libs/jar dependencies.
- In Travis configuration, licenses are installed automatically. Install Android version via sdkmanager to ensure licenses are all accepted correctly.
- Move preparing signing keystore to before_deploy to allow Travis builds to work for Pull Requests.