### PR TITLE
Simplify intent creation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,9 +17,6 @@
                  android:banner="@mipmap/banner"
                  android:theme="@style/Theme.Leanback"
                  tools:ignore="GoogleAppIndexingWarning">
-        <meta-data android:name="serviceUrl" android:value="@string/serviceUrl" />
-        <meta-data android:name="serviceName" android:value="@string/serviceName" />
-
         <activity android:name="hosh.io.atv_launchers.GenericLauncher"
                   android:taskAffinity="hosh.io.atv_launchers.GenericLauncher"
                   android:excludeFromRecents="true" >

--- a/app/src/main/java/hosh/io/atv_launchers/GenericLauncher.java
+++ b/app/src/main/java/hosh/io/atv_launchers/GenericLauncher.java
@@ -2,18 +2,12 @@ package hosh.io.atv_launchers;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.content.pm.ActivityInfo;
-import android.content.pm.ApplicationInfo;
 import android.os.Bundle;
 import android.util.Log;
-import android.content.pm.PackageManager;
 
 public class GenericLauncher extends Activity {
     // am start -a com.sony.dtv.hbbtvlauncher.LaunchHbbTV -n com.sony.dtv.hbbtvlauncher/.LaunchHbbTV
     // -e HBBTV_LAUNCHER_INFO "type=bi, service=All4, url=https://yvweb.channel4.com/yvwebapp//"
-
-    private String serviceName = "Undefined";
-    private String serviceUrl = "Undefined";
 
     protected void onCreate(Bundle bundle) {
         super.onCreate(bundle);
@@ -23,20 +17,10 @@ public class GenericLauncher extends Activity {
     }
 
     private Intent getYouViewIntent() {
-        try {
-            ApplicationInfo ai = getPackageManager().getApplicationInfo(getPackageName(), PackageManager.GET_META_DATA);
-            Bundle bundle = ai.metaData;
-            if (bundle != null) {
-                serviceName = bundle.getString("serviceName");
-                serviceUrl = bundle.getString("serviceUrl");
-            }
-        } catch (PackageManager.NameNotFoundException e) {
-            Log.e(this.getClass().getSimpleName(), "Failed to load meta-data, NameNotFound: " + e.getMessage());
-        } catch (NullPointerException e) {
-            Log.e(this.getClass().getSimpleName(), "Failed to load meta-data, NullPointer: " + e.getMessage());
-        }
+        String serviceName = getString(R.string.serviceName);
+        String serviceUrl = getString(R.string.serviceUrl);
 
-        Log.d(this.getClass().getSimpleName(), "Launching serviceName : " + serviceName + " and serviceURL : " + serviceUrl);
+        Log.d(getClass().getSimpleName(), "Launching serviceName : " + serviceName + " and serviceURL : " + serviceUrl);
 
         Intent intent = new Intent();
         intent.setClassName("com.sony.dtv.hbbtvlauncher", "com.sony.dtv.hbbtvlauncher.LaunchHbbTV");


### PR DESCRIPTION
The service name and URL can just be read straight from string resources, rather than doing it via the AndroidManifest. This greatly simplifies the code and makes the apps do even less in order to launch to apps.