### PR TITLE
Remove &amp;launch_mode=video_only from UKTVPlay app.

### DIFF
--- a/app/src/uktvPlay/res/values/strings.xml
+++ b/app/src/uktvPlay/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
     <string name="label">UKTV Play</string>
-    <string name="serviceUrl">https://tvapp.uktv.co.uk/?brand=default&amp;model=fvp&amp;launch_mode=video_only&amp;house_num=None</string>
+    <string name="serviceUrl">https://tvapp.uktv.co.uk/?brand=default&amp;model=fvp&amp;house_num=None</string>
     <string name="serviceName">UKTV Play</string>
 </resources>


### PR DESCRIPTION
Sony KD-55XE8596 (Android 8) - UKTVPlay app had spinning circle on startup no timeout.

Some investigation implies 'launch_mode=video_only' is causing the issue.

App works fine without this URI argument on above TV.....